### PR TITLE
docs(gha): Workflow for automated releases

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,42 @@
+name: Create Helm Package After Agent Release
+on:
+  repository_dispatch:
+    types: [agentRelease]
+jobs:
+  createHelmPackage:
+    runs-on: ubuntu-latest
+    env:
+      HELM_URL: https://get.helm.sh
+      HELM_VERSION: 3.1.1
+      HELM_TARBALL: helm-v${HELM_VERSION}-linux-amd64.tar.gz
+      HELM_INSTALLATION_FOLDER: ~/helm
+      HELM_HOME: ${HELM_INSTALLATION_FOLDER}/linux-amd64
+      ARMORY_JFROG_CHARTS_URL: https://armory.jfrog.io/artifactory/charts
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+      - name: Install Helm
+        run: |
+          set -eu
+          echo "Installing Helm..."
+          [ -d ${{env.HELM_INSTALLATION_FOLDER}} ] || mkdir ${{env.HELM_INSTALLATION_FOLDER}}
+          cd ${{env.HELM_INSTALLATION_FOLDER}}
+          curl -f --user-agent curl-ci-sync -sSL -o "${{env.HELM_TARBALL}}" "${{env.HELM_URL}}/${{env.HELM_TARBALL}}"
+          tar -xzf "${{env.HELM_TARBALL}}"
+      - name: Publish Agent Helm Package
+        run: |
+          set -eu
+          echo "Publising agent helm chart..."
+          PATH="${{env.HELM_HOME}}/:${PATH}"
+          sed 's/{{version}}/${{github.event.client_payload.version}}/' Chart.yaml > ChartTemp.yaml
+          mv ChartTemp.yaml Chart.yaml
+          sed 's/{{appVersion}}/${{github.event.client_payload.appVersion}}/' Chart.yaml > ChartTemp.yaml
+          mv ChartTemp.yaml Chart.yaml
+          [ -d helm ] || mkdir helm
+          cd helm
+          helm package ../
+          curl -f -u ${{secrets.JFROG_USER}}:${{secrets.JFROG_PASSWORD}} -o "index.yaml" "${{env.ARMORY_JFROG_CHARTS_URL}}/index.yaml"
+          helm repo index --merge index.yaml --url "${{env.ARMORY_JFROG_CHARTS_URL}}" .
+          for f in *; do
+            curl -f -u ${{secrets.JFROG_USER}}:${{secrets.JFROG_PASSWORD}} -X PUT "${{env.ARMORY_JFROG_CHARTS_URL}}/${f}" -T "${PWD}/${f}"
+          done

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+.idea

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -4,10 +4,10 @@ description: An easy way to install armory's agent for kubernetes
 
 type: application
 
-version: 0.2.1
+version: {{version}}
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.7.0-rc.1"
+appVersion: "{{appVersion}}"

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Calling GitHub API using curl command:
         -H "Accept: application/vnd.github.v3+json" \
         -H "Authorization: token {GIT_HUB_TOKEN}" \
         https://api.github.com/repos/{REPOSITORY_OWNER}/{REPOSITORY_NAME}/dispatches \
-        -d '{"event_type":"agentRelease", "client_payload":{"version":"{AGENT_VERSION}"}}'
+        -d '{"event_type":"agentRelease", "client_payload":{"version":"{HELM_VERSION}", "appVersion":"{AGENT_VERSION}"}}'
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -65,6 +65,26 @@ This chart also supports passing of settings using helm variables present in the
 | cloudEnabled | `true` |
 | kubernetes | refer to Kubernetes specific options in [armory.io](https://docs.armory.io/docs/armory-agent/agent-options/#configuration-options) |
 
+## GitHub Actions
+
+### Create Helm Package After Agent Release
+
+This workflow is exposed by GitHub API, and it basically creates and publish the agent-k8s component
+into a helm package. 
+
+It was meant to be use by [armory-io/agent-k8s](https://github.com/armory-io/agent-k8s/blob/5b914180aea2602f0a6152e34194463b26b45177/.github/workflows/build.yml) 
+workflow when there is a new release of it, but we always can trigger it by calling the GitHub API.
+
+Calling GitHub API using curl command:
+
+```
+    curl -X POST \
+        -H "Accept: application/vnd.github.v3+json" \
+        -H "Authorization: token {GIT_HUB_TOKEN}" \
+        https://api.github.com/repos/{REPOSITORY_OWNER}/{REPOSITORY_NAME}/dispatches \
+        -d '{"event_type":"agentRelease", "client_payload":{"version":"{AGENT_VERSION}"}}'
+```
+
 ## License
 
 © 2021 Armory Inc. All rights reserved.


### PR DESCRIPTION
Pack the received agent version into a helm package and publish it to jfrog.
The agent-k8s will be incharge of trigger this functionality by making a curl
and thanks of the repository_dispatcher inside of the workflow of this code it
will run the whole workflow.

Jira REQ : https://armory.atlassian.net/browse/RBK-280