### PR TITLE
fix(inf): fix account loading in infra mode

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -1,0 +1,9 @@
+{{/* Referenced by the Deployment and Secret manifests when using infrastructure mode. */}}
+{{- define "kubeconfig-secret-name" -}}
+  {{ .Name | lower }}-kubeconfig-secret
+{{- end -}}
+
+{{/* Referenced by the Deployment manifest when using infrastructure mode. */}}
+{{- define "kubeconfig-volume-name" -}}
+  volume-{{ .Name | lower }}-kubeconfigs
+{{- end -}}

--- a/templates/clusterrole.yml
+++ b/templates/clusterrole.yml
@@ -1,3 +1,4 @@
+{{- if (eq $.Values.mode "agent") }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -127,3 +128,4 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: {{ .Release.Name | lower }}-cluster-role
+{{- end}}

--- a/templates/configmap.yml
+++ b/templates/configmap.yml
@@ -32,34 +32,36 @@ data:
           verify: true
       {{- end }}
 
-    {{- with .Values.kubernetes }}
+    {{- if .Values.accounts }}
     kubernetes:
-      accounts:      
-      {{- range $index, $account := .accounts }}
-      {{- if eq $index 0 }}
-      - name: {{ required "At least one account name must be specified, use: --set accountName=..." $.Values.accountName }}
-      {{- else }}
-      - name: {{ $account.name }}
-      {{- end }}
-        {{- range $key, $val := $account -}}
-        {{- if not (or (eq $key "serviceAccount") (eq $key "kubeconfigFile")) }}        
-        {{- if and (eq $key "namespaces") $account.onlyNamespacedResources }}
-        namespaces: {{ $account.namespaces }}
-        {{- else if (eq $key "customResourceDefinitions") }}
-        customResourceDefinitions:
-        {{- range $in, $crd := $account.customResourceDefinitions }}
-        - kind: {{ $crd.kind }}
-        {{- end }}
-        {{- else if not (eq $key "name")}}
-        {{ $key }}: {{ $val }}
-        {{- end -}}
-        {{- end -}}
-      {{- end -}}
-        {{- if or (eq $.Values.mode "agent") $account.serviceAccount }}
-        serviceAccount: true
-        {{- else }}
-        kubeconfigFile: /kubeconfigfiles/config
-        {{- end }}
-      {{- end -}}
-    {{- end -}}
+      accounts:
+      {{- range .Values.accounts }}
+        - name: {{ .name }}
+          kubeconfigFile: /kubeconfigfiles/{{ $.Release.Name | lower }}-{{ .name }}
+          {{- if .onlyNamespacedResources }}
+          onlyNamespacedResources: {{ .onlyNamespacedResources }}
+          namespaces: {{ .namespaces }}
+          {{- end }}
+          {{- with .omitNamespaces }}
+          omitNamespaces: {{ . }}
+          {{- end }}
+          {{- with .customResourceDefinitions }}
+          customResourceDefinitions:
+            {{- range . }}
+            - kind: {{ . }}
+            {{- end}}
+          {{- end }}
+          {{- with .kinds }}
+          kinds: {{ . }}
+          {{- end }}
+          {{- with .omitKinds }}
+          omitKinds: {{ . }}
+          {{- end }}
+      {{- end}}
+    {{- else }}
+    kubernetes:
+      accounts:
+        - name: {{ required "`accountName` must be defined when using 'agent' mode." $.Values.accountName }}
+          serviceAccount: true
+    {{- end }}
 {{- end }}

--- a/templates/deployment.yml
+++ b/templates/deployment.yml
@@ -20,7 +20,9 @@ spec:
         app.kubernetes.io/name: armory-agent
         cluster: {{ .Release.Name | lower }}-cluster
     spec:
+      {{- if (eq $.Values.mode "agent") }}
       serviceAccount: {{ .Release.Name | lower }}-sa
+      {{- end }}
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
       - name: {{ .Values.imagePullSecrets }}
@@ -64,18 +66,18 @@ spec:
         volumeMounts:
         - mountPath: /opt/armory/config
           name: volume-{{ .Release.Name | lower }}-config
-        {{- if not (eq $.Values.mode "agent") }}
+        {{- with .Values.accounts }}
         - mountPath: /kubeconfigfiles
-          name: volume-{{ .Release.Name | lower }}-kubeconfigs
-        {{- end}}
+          readOnly: true
+          name: {{ template "kubeconfig-volume-name" $.Release }}
+        {{- end }}
       restartPolicy: Always
       volumes:
       - name: volume-{{ .Release.Name | lower }}-config
         configMap:
           name: {{ .Release.Name | lower }}-config
-      {{- if not (eq $.Values.mode "agent") }}
-      - name: volume-{{ .Release.Name | lower }}-kubeconfigs
+      {{- with $.Values.accounts }}
+      - name: {{ template "kubeconfig-volume-name" $.Release }}
         secret:
-          defaultMode: 420
-          secretName: {{ .Release.Name | lower }}-secret
+          secretName: {{ template "kubeconfig-secret-name" $.Release }}
       {{- end }}

--- a/templates/kubeconfig-secret.yml
+++ b/templates/kubeconfig-secret.yml
@@ -3,8 +3,16 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Release.Name | lower }}-secret
+  name: {{ template "kubeconfig-secret-name" .Release }}
 type: Opaque
 data:
-  config: {{ .Values.kubeconfig| b64enc }}
+  {{/* Secret limits are 1MB. The largest single kubeconfig we've seen is about
+  10kb, so there's about a 100 kubeconfig limit here give or take some bytes.
+
+  If we hit a use case where users are running into size limits on secrets we
+  can revisit the decision to pack them into a single secret.
+  */}}
+  {{ range .Values.accounts }}
+  {{ $.Release.Name | lower }}-{{ .name }}: {{ .kubeconfig | b64enc }}
+  {{- end }}
 {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -1,8 +1,41 @@
 grpcUrl:  agents.cloud.armory.io:443
 mode: agent
 cloudEnabled: true
-kubernetes:
-  accounts:
-  - name: account1
-
 env: []
+
+# Examples
+
+## NOTE: If you are installing the agent in "agent mode" then you must set an
+## account name. This name will be used in the Spinnaker Aurora plugin.
+# accountName: my-cluster
+
+## NOTE: The following settings will enable the agent to run in
+## "infrastructure mode", which allows the definition of multiple remote
+## Kubernetes accounts for a single agent.
+#mode: infrastructure
+#accounts:
+  #- name: my-remote-account
+    ## NOTE: `kubeconfig` can also be set at invocation time with --set-file if
+    ## you do not wish to embed it in your values.yaml file.
+    ##
+    ## NOTE: if you do not already have a kubeconfig file for your target cluster,
+    ##       you can create one with the following instructions:
+    ##       https://docs.armory.io/docs/armory-admin/manual-service-account/
+    #kubeconfig: |
+      #apiVersion: v1
+      #kind: Config
+      #clusters:
+      #- cluster:
+          #certificate-authority-data: example
+          #server: https://example.com
+        #name: example-cluster
+      #contexts:
+      #- context:
+          #cluster: example-cluster
+          #user: example-user
+        #name: example-cluster
+      #current-context: example-cluster
+      #users:
+      #- name: example-user
+        #user:
+          #token: my-token


### PR DESCRIPTION
Account kubeconfig files were not being mounted correctly under the
previous config format. This commit introduces the ability to mount
arbitrary numbers of kubeconfig files passed in via invocation or
values.yml files. These files are then loaded into an opaque secret and
given a unique name relative to the helm chart. This secret will then be
mounted into the agent container and referenced by name in the agent
config file. This preserves prior behavior allowing the user to define
kinds, namespaces, etc.

Additionally, this PR removes the service account and role created when
running in infrastructure mode. IOW, this change makes it mutually
exclusive to run in either agent more OR infrastructure mode, but not
both.

Here's an example of what this looks like with two accounts configured:
```shell
armory@aurora-5f4d6d955f-tm56w:/$ ls /kubeconfigfiles/
aurora-ffreire-remote  aurora-satwell-remote

armory@aurora-5f4d6d955f-tm56w:/$ cat /opt/armory/config/armory-agent.yml
hub:
  connection:
    grpc: agents.staging.cloud.armory.io:443
  auth:
    armory:
      clientId: <removed>
      secret: <removed>
      tokenIssuerUrl: https://auth.staging.cloud.armory.io/oauth/token
      audience: https://api.staging.cloud.armory.io
      verify: true
kubernetes:
  accounts:
    - name: ffreire-remote
      kubeconfigFile: /kubeconfigfiles/aurora-ffreire-remote
    - name: satwell-remote
      kubeconfigFile: /kubeconfigfiles/aurora-satwell-remote

```