### PR TITLE
feat(ops): enable users to specify annotations and labels

### DIFF
--- a/templates/deployment.yml
+++ b/templates/deployment.yml
@@ -19,6 +19,17 @@ spec:
         app: armory-agent
         app.kubernetes.io/name: armory-agent
         cluster: {{ .Release.Name | lower }}-cluster
+{{- if .Values.podLabels}}
+      {{- range $key, $value := .Values.podLabels }}
+        {{ $key }}: {{ $value | quote }}
+      {{- end }}
+{{- end }}
+{{- if .Values.podAnnotations}}
+      annotations:
+      {{- range $key, $value := .Values.podAnnotations }}
+        {{ $key }}: {{ $value | quote }}
+      {{- end }}
+{{- end }}
     spec:
       {{- if (eq $.Values.mode "agent") }}
       serviceAccount: {{ .Release.Name | lower }}-sa

--- a/values.yaml
+++ b/values.yaml
@@ -3,6 +3,16 @@ mode: agent
 cloudEnabled: true
 env: []
 
+# Additional labels to add to the pods:
+# podLabels:
+#   key: value
+podLabels: {}
+
+# Additional annotations for pods
+# podAnnotations:
+#   key: value
+podAnnotations: {}
+
 # Examples
 
 ## NOTE: If you are installing the agent in "agent mode" then you must set an


### PR DESCRIPTION
This allows users to specify annotations and labels for the deployment pods

![image](https://user-images.githubusercontent.com/711726/142455783-6977ac3a-a60a-492c-a61b-aebbe46b9d67.png)

I tested this via manipulating the `values.yaml` file and running the following command

```
helm template --set clientId=foo --set clientSecret=bar --set accountName=muh-accountname --namespace muh-namespace ./ > manifests_with_annotations_and_labels.yaml
```

As you can see :point_down: the deployment has the labels and annotations when present in the `values.yaml` file and not when absent from the values files

![Screenshot from 2021-11-18 08-22-30](https://user-images.githubusercontent.com/711726/142455685-4b8e39b1-dff7-4a18-b326-bef430daf74f.png)
![Screenshot from 2021-11-18 08-22-13](https://user-images.githubusercontent.com/711726/142455688-b4518487-3eb7-4083-910f-16214939dfa4.png)
